### PR TITLE
商品一覧表示機能no

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-     # @items = Item.all
+      @items = Item.includes(:user).order("created_at DESC")
   end
 
   

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -163,8 +163,9 @@
 
       <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+
+      <% if @items.empty? %>
+      
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -182,8 +183,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+
+      <% end %>
+
+
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
     </div>
     <ul class='item-lists'>
 
-      <%# @items.each do |item| %>
+      <% @items.each do |item| %>
 
       <li class='list'>
 
@@ -137,10 +137,10 @@
         
         
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+     <%#  <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
@@ -148,10 +148,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -161,7 +161,7 @@
         <% end %>
       </li>
 
-      <%# end %>
+      <% end %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>


### PR DESCRIPTION
＃What
商品一覧表示機能の実装

＃Why
出品された商品はトップページに一覧で表示されること。

 1.[商品のデータがない場合は、ダミー商品が表示されている動画](https://gyazo.com/ab460162800e924c09a833fd65a07620)
 2.[商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）](https://gyazo.com/ef911a3f53dad32282eca2606982cf77)